### PR TITLE
Defend against missing colons

### DIFF
--- a/Scraper.py
+++ b/Scraper.py
@@ -31,28 +31,31 @@ class Scraper:
 
     @staticmethod
     def item_type(item: str) -> str:
-        if item.lower().startswith("soup:") or item.lower().startswith("soep:"):
+        if item.lower().startswith("soup") or item.lower().startswith("soep"):
             return "soup"
-        elif item.lower().startswith("menu 1:"):
+        elif item.lower().startswith("menu 1"):
             return "menu 1"
-        elif item.lower().startswith("menu 2:"):
+        elif item.lower().startswith("menu 2"):
             return "menu 2"
-        elif item.lower().startswith("fish:"):
+        elif item.lower().startswith("fish"):
             return "fish"
-        elif item.lower().startswith("vis:"):
+        elif item.lower().startswith("vis"):
             return "fish"
-        elif item.lower().startswith("veggie:"):
+        elif item.lower().startswith("veggie"):
             return "veggie"
-        elif item.lower().startswith("pasta:"):
+        elif item.lower().startswith("pasta"):
             return "pasta"
-        elif item.lower().startswith("wok:"):
+        elif item.lower().startswith("wok"):
             return "wok"
         else:
             return "none"
 
     @staticmethod
     def item_name(item: str) -> str:
-        [_, name] = item.split(':', 1)
+        ch = ':'
+        if ':' not in item:
+            ch = ' '
+        [_, name] = item.split(ch, 1)
         name = name.strip()
         return name
 


### PR DESCRIPTION
Sometimes, people forget to type colons, and then we just play a bit around to avoid them.

Fixes this week's menu.

```
Traceback (most recent call last):
  File "/home/rsmet/src/vub-resto-scraper/main.py", line 94, in <module>
    main()
  File "/home/rsmet/src/vub-resto-scraper/main.py", line 77, in main
    jette_en = Generator.generate(scraper.get_restaurant(Scraper.jette_en))
  File "/home/rsmet/src/vub-resto-scraper/Scraper.py", line 120, in get_restaurant
    parsed = self.parse_restaurant(raw)
  File "/home/rsmet/src/vub-resto-scraper/Scraper.py", line 103, in parse_restaurant
    parsed = [{'day': Scraper.menu_date(day), 'menu': Scraper.parse_menu(day)} for day in menu]
  File "/home/rsmet/src/vub-resto-scraper/Scraper.py", line 103, in <listcomp>
    parsed = [{'day': Scraper.menu_date(day), 'menu': Scraper.parse_menu(day)} for day in menu]
  File "/home/rsmet/src/vub-resto-scraper/Scraper.py", line 97, in parse_menu
    items = [Scraper.parse_item(item) for item in items]
  File "/home/rsmet/src/vub-resto-scraper/Scraper.py", line 97, in <listcomp>
    items = [Scraper.parse_item(item) for item in items]
  File "/home/rsmet/src/vub-resto-scraper/Scraper.py", line 87, in parse_item
    name = Scraper.item_name(item)
  File "/home/rsmet/src/vub-resto-scraper/Scraper.py", line 56, in item_name
    [_, name] = item.split(':', 1)
ValueError: not enough values to unpack (expected 2, got 1)