### PR TITLE
Allow manual list item bullets instead of ul/li

### DIFF
--- a/Scraper.py
+++ b/Scraper.py
@@ -32,21 +32,22 @@ class Scraper:
 
     @staticmethod
     def item_type(item: str) -> str:
-        if item.lower().startswith("soup") or item.lower().startswith("soep"):
+        item = item.lower().strip("•").strip()
+        if item.startswith("soup") or item.startswith("soep"):
             return "soup"
-        elif item.lower().startswith("menu 1"):
+        elif item.startswith("menu 1"):
             return "menu 1"
-        elif item.lower().startswith("menu 2"):
+        elif item.startswith("menu 2"):
             return "menu 2"
-        elif item.lower().startswith("fish"):
+        elif item.startswith("fish"):
             return "fish"
-        elif item.lower().startswith("vis"):
+        elif item.startswith("vis"):
             return "fish"
-        elif item.lower().startswith("veggie"):
+        elif item.startswith("veggie"):
             return "veggie"
-        elif item.lower().startswith("pasta"):
+        elif item.startswith("pasta"):
             return "pasta"
-        elif item.lower().startswith("wok"):
+        elif item.startswith("wok"):
             return "wok"
         else:
             return "none"
@@ -75,7 +76,7 @@ class Scraper:
 
     @staticmethod
     def possible_item(item: str) -> bool:
-        item = item.lower()
+        item = item.lower().strip("•").strip()
         for prefix in ["soup", "soep", "wok", "fish", "vis", "veggie", "menu 1", "menu 2", "pasta", "wok"]:
             if item.startswith(prefix):
                 return True


### PR DESCRIPTION
Current format for Etterbeek is this, with `<br/>`. Jette is still normal ul/li...
```
•    Soep: Bloemkoolsoep
•    Menu 1: Vol-au-vent met warme groentjes
•    Menu 2: Heekfilet dijonaise
•    Veggie: Vegan stoverij
•    Pasta: Spaghetti Bolognaise
•    Wok: Curryschotel met zoete aardappel, linzen en spinazie (vegan)
```