### PR TITLE
Bugfix to allow parsing VUB's mistakes in week 41.

### DIFF
--- a/Scraper.py
+++ b/Scraper.py
@@ -124,7 +124,7 @@ class Scraper:
                 if goodstuff.string:
                     goodstuff = goodstuff.string.strip()
                 elif goodstuff.contents:  #FUCKING IDIOTS
-                    goodstuff = "".join(goodstuff.contents).strip()
+                    goodstuff = "".join(goodstuff.get_text()).strip()
                 else:
                     print("ERROR:", goodstuff)
                 items.append(Scraper.parse_item(goodstuff))


### PR DESCRIPTION
Current main code crashes while scraping week 41 menu on the included <br> tags. What a nice an healthy change from the previous <span> spamming. 

Proposed code should just only use the text and ignore all tags, at least as far as my non existing BS (interpret as you wish) skills go. Fingers crossed this makes it more than a week.